### PR TITLE
Default to catalog view and collapse class tables by default

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,9 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Routes} from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes, Navigate} from 'react-router-dom';
 import PageTemplate from './PageTemplate';
 import './modalStyles.css'
 import './App.css';
-
+import { latestSemester } from './LatestSemester';
 
 
 function App() {
@@ -24,7 +24,7 @@ return (
 
     <Route path="/search" element={<PageTemplate target={"search"}/>}/>
     <Route path="/search/:query" element={<PageTemplate target={"search"}/>}/>
-    <Route path="/" element={<PageTemplate target={"search"}/>} />
+    <Route path="/" element={<Navigate to={`/catalog/${latestSemester}`} />} />
     </Routes>
   </Router>
 )

--- a/src/CatalogPage.js
+++ b/src/CatalogPage.js
@@ -11,7 +11,7 @@ function CatalogPage() {
   const navigate = useNavigate();
 
   const [tableExpansions, setTableExpansions] = useState({});
-  const [allTablesExpanded, setAllTablesExpanded] = useState(true); // state for overall table expansion
+  const [allTablesExpanded, setAllTablesExpanded] = useState(false); // state for overall table expansion
 
   const [allSemesters, setAllSemesters] = useState([]);
   const [selectedSemester, setSelectedSemester] = useState(semester);
@@ -64,12 +64,16 @@ function CatalogPage() {
       for (const [, courseArr] of Object.entries(data)) {
         for (const course of courseArr) {
           const tableKey = `${course.subject}${course.catalog_number}`;
-          newTableExpansions[tableKey] = allTablesExpanded;
+          newTableExpansions[tableKey] = false;
         }
       }
+      if (org && number) {
+        newTableExpansions[`${org}${number}`] = true;
+      }
       setTableExpansions(newTableExpansions);
+      setAllTablesExpanded(false);
     }
-  }, [data, allTablesExpanded]);
+  }, [data, org, number]);
 
 
 
@@ -130,12 +134,15 @@ function CatalogPage() {
 
   // Toggle the expansion state of all tables
   const toggleAllTablesExpansion = () => {
-    setAllTablesExpanded((prev) => !prev);
-    const newExpansionState = Object.keys(tableExpansions).reduce((state, tableKey) => {
-      state[tableKey] = !allTablesExpanded;
-      return state;
-    }, {});
-    setTableExpansions(newExpansionState);
+    setAllTablesExpanded(prev => {
+      const newState = !prev;
+      const newExpansionState = Object.keys(tableExpansions).reduce((state, tableKey) => {
+        state[tableKey] = newState;
+        return state;
+      }, {});
+      setTableExpansions(newExpansionState);
+      return newState;
+    });
   };
 
 


### PR DESCRIPTION
## Summary
- Redirect root path to latest semester catalog view
- Collapse catalog tables initially and expand targeted class from URL
- Update table expand-all logic

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden for netlify-cli dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c10715da988328a7898582928670a2