### PR TITLE
Swap catalog and search positions in nav bar

### DIFF
--- a/src/PageTemplate.js
+++ b/src/PageTemplate.js
@@ -106,8 +106,8 @@ function PageTemplate(props){
 
 
         <div className="nav-bar">
-          <a className={`nav-button ${renderTarget === 'search' ? 'underlined' : ''}`} href="/search">Search</a>
           <a className={`nav-button ${renderTarget === 'catalog' || renderTarget === 'catalog-page' || renderTarget === 'catalog-semester-list' ? 'underlined' : ''}`} href={`/catalog/${latestSemester}`}>Catalog</a>
+          <a className={`nav-button ${renderTarget === 'search' ? 'underlined' : ''}`} href="/search">Search</a>
         </div>
         {content}
       </header>


### PR DESCRIPTION
## Summary
- place Catalog link before Search in the navigation bar

## Testing
- ⚠️ `CI=true npm test` *(missing dependencies: react-scripts not found)*
- ⚠️ `npm install` *(failed: 403 Forbidden when fetching netlify-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d29bcf1c832899455af6b81f9d8b