### PR TITLE
Refine catalog table layout

### DIFF
--- a/src/Catalog.css
+++ b/src/Catalog.css
@@ -211,6 +211,31 @@ body{
 
 .meeting-table{
   width: 100%;
+  vertical-align: top;
+}
+
+.meeting-table-head,
+.meeting-table-content,
+.meeting-row {
+  width: 100%;
+}
+
+.meeting-table-head,
+.meeting-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 12px;
+  text-align: center;
+}
+
+.meeting-table-content {
+  display: grid;
+  row-gap: 6px;
+}
+
+.meeting-row .days,
+.meeting-row .time {
+  display: block;
 }
 
 .days{
@@ -247,10 +272,11 @@ tr{
 
 
 .catalogPage .custom-table {
-  width: 1000px; /* Set the fixed width for the entire table */
+  width: 100%;
+  max-width: 1000px; /* Limit the table width on large screens */
   border: 1px solid #fff;
   border-radius: 3px;
-  display: inline-block; 
+  table-layout: fixed;
 }
 
 .custom-table th, .custom-table td {
@@ -338,8 +364,8 @@ tr{
 
 
 /* Style for all rows of the inner table */
-.custom-table tr:nth-child(even) .meeting-table tr,
-.custom-table tr:nth-child(odd) .meeting-table tr {
+.custom-table tr:nth-child(even) .meeting-table .meeting-row,
+.custom-table tr:nth-child(odd) .meeting-table .meeting-row {
   background-color: inherit; /* Inherit background color from outer table */
 }
 
@@ -458,8 +484,8 @@ tr.title-header:hover th{
   }
 
   /* Style for all rows of the inner table */
-  .catalogPage .custom-table tr:nth-child(even) .meeting-table tr,
-  .catalogPage .custom-table tr:nth-child(odd) .meeting-table tr {
+  .catalogPage .custom-table tr:nth-child(even) .meeting-table .meeting-row,
+  .catalogPage .custom-table tr:nth-child(odd) .meeting-table .meeting-row {
       background-color: inherit; /* Inherit background color from outer table */
   }
 

--- a/src/CatalogPage.js
+++ b/src/CatalogPage.js
@@ -147,17 +147,23 @@ function CatalogPage() {
 
 
   const generateMeetingTable = (meetings) => {
-    if (!meetings) {
-      return "TBA";
+    if (!meetings || meetings.length === 0) {
+      return [
+        <div className="meeting-row" key="meeting-tba">
+          <span className="days">TBA</span>
+          <span className="time">TBA</span>
+        </div>
+      ];
     }
-    const table = [];
 
-    for (const meeting of meetings) {
-      const meetingDays = meeting.days === '-' ? 'TBA' : meeting.days;
+    const rows = [];
+
+    for (const [index, meeting] of meetings.entries()) {
+      const meetingDays = meeting?.days === '-' ? 'TBA' : (meeting?.days || 'TBA');
 
       const hasTime =
-        meeting.start_time &&
-        meeting.end_time &&
+        meeting?.start_time &&
+        meeting?.end_time &&
         meeting.start_time !== '-' &&
         meeting.end_time !== '-';
 
@@ -165,15 +171,16 @@ function CatalogPage() {
         ? `${meeting.start_time}-${meeting.end_time}`
         : 'TBA';
 
-      table.push(
-        <tr className='meeting-table'>
-          <td className="days">{meetingDays}</td>
-          <td className="time">{meetingTimeString}</td>
-        </tr>
+      rows.push(
+        <div className="meeting-row" key={`meeting-${meetingDays}-${meetingTimeString}-${index}`}>
+          <span className="days">{meetingDays}</span>
+          <span className="time">{meetingTimeString}</span>
+        </div>
       );
     }
-    return table;
-  }
+
+    return rows;
+  };
 
   const generateInstructorHTML = (instructors) => {
     const elements = [];
@@ -294,14 +301,10 @@ function CatalogPage() {
             <th className="instructor">Instructor</th>
             <th className="enrollment">Enrollment</th>
             <th className="meeting-table">
-              <table>
-                <tbody>
-                  <tr>
-                    <td className='table-header'>Days</td>
-                    <td className='table-header'>Time</td>
-                  </tr>
-                </tbody>
-              </table>
+              <div className='meeting-table-head'>
+                <span className='table-header'>Days</span>
+                <span className='table-header'>Time</span>
+              </div>
             </th>
           </tr>
         );
@@ -314,8 +317,11 @@ function CatalogPage() {
             <td className="section-number">{classSectionString}</td>
             <td className="instructor">{generateInstructorHTML(section.instructors)}</td>
             <td className="enrollment">{`${section.enrollment_total}/${section.class_capacity}`}</td>
-            <td className='meeting-table'><table>
-            {generateMeetingTable(section.meetings)}</table>  </td>
+            <td className='meeting-table'>
+              <div className='meeting-table-content'>
+                {generateMeetingTable(section.meetings)}
+              </div>
+            </td>
           </tr>);
         }
 


### PR DESCRIPTION
## Summary
- render meeting information with flexibly-sized rows instead of nested tables so columns stay aligned
- apply a fixed table layout and responsive width constraints to keep catalog tables neat across screen sizes
- gracefully handle missing meeting data so every section shows a consistent Days/Time pair

## Testing
- npm run build *(fails: `react-scripts` missing because dependencies cannot be installed — `npm install` blocked by 403 fetching `tsutils`)*

------
https://chatgpt.com/codex/tasks/task_e_68d41548c0e88328be904aca388e4bdb