### PR TITLE
Improve catalog meeting table responsiveness

### DIFF
--- a/src/Catalog.css
+++ b/src/Catalog.css
@@ -210,7 +210,8 @@ body{
 }
 
 .meeting-table{
-  width: 100%;
+  width: auto;
+  max-width: 100%;
   vertical-align: top;
 }
 
@@ -236,6 +237,17 @@ body{
 .meeting-row .days,
 .meeting-row .time {
   display: block;
+  word-break: break-word;
+}
+
+.table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table-wrapper + .table-wrapper {
+  margin-top: 16px;
 }
 
 .days{
@@ -339,6 +351,50 @@ tr{
 
 .custom-table .collapsed {
   display: none;
+}
+
+@media (max-width: 768px) {
+  .custom-table th,
+  .custom-table td {
+    font-size: 14px;
+    padding: 6px;
+  }
+
+  .course-title {
+    font-size: 24px;
+  }
+
+  .meeting-table-head,
+  .meeting-row {
+    column-gap: 8px;
+  }
+}
+
+@media (max-width: 600px) {
+  .meeting-table-head,
+  .meeting-row {
+    grid-template-columns: 1fr;
+    row-gap: 2px;
+    text-align: left;
+  }
+
+  .meeting-table-head {
+    font-weight: bold;
+  }
+
+  .meeting-row .days::before {
+    content: 'Days: ';
+    font-weight: 600;
+  }
+
+  .meeting-row .time {
+    margin-top: 2px;
+  }
+
+  .meeting-row .time::before {
+    content: 'Time: ';
+    font-weight: 600;
+  }
 }
 
 

--- a/src/CatalogPage.js
+++ b/src/CatalogPage.js
@@ -326,7 +326,7 @@ function CatalogPage() {
         }
 
           elements.push(
-            <div>
+            <div className="table-wrapper">
               <table className={'custom-table'} id={tableKey}>
                 <tbody>{table}</tbody>
               </table>


### PR DESCRIPTION
## Summary
- wrap each catalog results table in a scrollable container to prevent horizontal overflow
- update meeting table styling to avoid width inflation and add word wrapping
- add responsive typography and mobile-friendly labels for days/time entries

## Testing
- CI=true npm test *(fails: `react-scripts` missing because dependencies could not be installed in this environment)*
- npm install *(fails: cannot download `tsutils` from the npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d55ff38f0883289eee6a55d341a557