### PR TITLE
Improve catalog meeting table responsiveness

### DIFF
--- a/src/Catalog.css
+++ b/src/Catalog.css
@@ -74,6 +74,28 @@ body{
   }
 }
 
+@media (max-width: 768px) {
+  .catalogPage .custom-table {
+    table-layout: auto;
+  }
+
+  .meeting-table-head,
+  .meeting-row {
+    grid-template-columns: 1fr;
+    row-gap: 6px;
+    text-align: left;
+    justify-items: start;
+  }
+
+  .meeting-table-head {
+    column-gap: 0;
+  }
+
+  .meeting-row .time {
+    margin-top: 2px;
+  }
+}
+
 .department-container {
   max-height: 0;
   overflow: hidden;
@@ -238,6 +260,10 @@ body{
   display: block;
 }
 
+.meeting-table-head .table-header {
+  display: block;
+}
+
 .days{
 }
 
@@ -270,6 +296,12 @@ tr{
   font-size: 16px;
 }
 
+
+.catalog-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
 
 .catalogPage .custom-table {
   width: 100%;

--- a/src/CatalogPage.js
+++ b/src/CatalogPage.js
@@ -326,7 +326,7 @@ function CatalogPage() {
         }
 
           elements.push(
-            <div>
+            <div className="catalog-table-wrapper">
               <table className={'custom-table'} id={tableKey}>
                 <tbody>{table}</tbody>
               </table>


### PR DESCRIPTION
## Summary
- wrap each catalog table in a scrollable container to prevent clipped content on narrow screens
- adjust meeting table grid styles so days and times stack vertically on mobile widths
- allow the catalog table layout to relax on small devices to avoid overflow

## Testing
- npm install *(fails: registry returned 403 for tsutils)*

------
https://chatgpt.com/codex/tasks/task_e_68d55ff38f0883289eee6a55d341a557