### PR TITLE
Fix mobile layout for meeting times

### DIFF
--- a/src/Catalog.css
+++ b/src/Catalog.css
@@ -609,19 +609,25 @@ tr.title-header:hover th{
 
   }
   .catalogPage .meeting-table{
-    width: 10%;
+    width: 100%;
   }
 
-  .catalogPage .days{
-    width: 9%;
+  .catalogPage .meeting-table-head,
+  .catalogPage .meeting-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    text-align: left;
   }
 
-  .catalogPage .time{
-    width: 9%;
+  .catalogPage .meeting-table-content {
+    row-gap: 4px;
   }
 
+  .catalogPage .days,
+  .catalogPage .time,
   .catalogPage .location{
-    width: 9%;
+    width: auto;
+    text-align: left;
+    word-break: break-word;
   }
 }
 


### PR DESCRIPTION
## Summary
- make the meeting schedule column span the full width on smaller screens
- left-align meeting headers and rows for improved readability on mobile
- allow meeting day/time text to wrap rather than overflow the table

## Testing
- npm test -- --watch=false *(fails: react-scripts not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d55ff38f0883289eee6a55d341a557