### PR TITLE
Improve mobile layout for catalog meeting details

### DIFF
--- a/src/Catalog.css
+++ b/src/Catalog.css
@@ -643,3 +643,33 @@ tr.title-header:hover th{
   }
 
 }
+
+@media (max-width: 600px) {
+  .catalogPage .custom-table {
+    table-layout: auto;
+  }
+
+  .catalogPage .section-type,
+  .catalogPage .section-number,
+  .catalogPage .instructor,
+  .catalogPage .enrollment,
+  .catalogPage .meeting-table {
+    width: auto;
+  }
+
+  .catalogPage .meeting-table {
+    min-width: 140px;
+  }
+
+  .catalogPage .meeting-table-head,
+  .catalogPage .meeting-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 8px;
+    text-align: left;
+  }
+
+  .catalogPage .meeting-row .days,
+  .catalogPage .meeting-row .time {
+    word-break: break-word;
+  }
+}


### PR DESCRIPTION
## Summary
- allow the catalog results table to switch to automatic column sizing on very small screens
- remove rigid column widths so the meeting details column can grow and stay within the table
- ensure the days/time grid wraps cleanly and left-aligns on narrow viewports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d55ff38f0883289eee6a55d341a557